### PR TITLE
Hide incomplete code-is-all-you-need post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,10 @@ include:
   - _pages
   - CNAME
 
+# Hidden / incomplete posts — kept in source, not published
+exclude:
+  - posts/code-is-all-you-need
+
 # Plugins (previously gems:)
 plugins:
   - jekyll-paginate

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -59,11 +59,6 @@ permalink: /posts/
   </div>
 
   <div class="blog-entry">
-    <a href="/posts/code-is-all-you-need/" class="blog-title">Code Is All You Need: Reframing Feature Engineering as Code</a>
-    <span class="blog-date">Jun 2026</span>
-  </div>
-
-  <div class="blog-entry">
     <a href="/posts/harbor-rlvr-environment/" class="blog-title">What Can't Be Measured Can't Be Solved: RLVR Environment Design from a Failure Taxonomy</a>
     <span class="blog-date">Jun 2026</span>
   </div>


### PR DESCRIPTION
Hides the incomplete `code-is-all-you-need` post:
- Remove from the /posts/ listing (`_pages/posts.md`)
- Exclude the directory from the Jekyll build (`_config.yml`) so the direct URL 404s

Source files kept in the repo. Also carries the earlier 'Hide Devin Fusion post' commit that was on this branch and not yet merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)