### PR TITLE
Posts page: Blog/Thoughts filter + Cognition-style design system

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,9 @@ include:
 # Hidden / incomplete posts — kept in source, not published
 exclude:
   - posts/code-is-all-you-need
+  - vendor
+  - Gemfile
+  - Gemfile.lock
 
 # Plugins (previously gems:)
 plugins:

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -5,4 +5,4 @@
 <!-- Google Fonts import -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Inter:wght@300;400;500;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400&family=Inter:wght@300;400;500;600;700&display=swap">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/academicons@1.9.2/css/academicons.min.css">
 

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -75,7 +75,7 @@ permalink: /posts/
 
   <div class="blog-entry" data-type="blog">
     <a href="https://supergeneral.vercel.app/" class="blog-title" target="_blank">SuperGeneral: Compositional Tool Environments for Agent Training</a>
-    <span class="blog-date">Mar 2026</span>
+    <span class="blog-date">03.10.26</span>
   </div>
 
   <div class="blog-entry" data-type="blog">

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -83,7 +83,7 @@ permalink: /posts/
     <span class="blog-date">Feb 2026</span>
   </div>
 
-  <div class="blog-entry" data-type="blog">
+  <div class="blog-entry" data-type="thoughts">
     <a href="/posts/ieee-most-panel" class="blog-title">IEEE MOST Panel: Driving Force Towards Large-Scale AV Commercialization</a>
     <span class="blog-date">May 2025</span>
   </div>

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -15,28 +15,16 @@ permalink: /posts/
   </div>
 </div>
 
-<div class="motto-section">
-  <div class="motto-container">
-    <div class="motto-quote">
-      Pain is inevitable but suffering is optional
-    </div>
-    <div class="motto-attribution">
-      — Haruki Murakami
-    </div>
-
-  </div>
-</div>
-
 <div class="posts-layout">
   <nav class="posts-filter" aria-label="Post type filter">
-    <button class="filter-item is-active" data-filter="all">All</button>
-    <button class="filter-item" data-filter="blog">Blog</button>
+    <button class="filter-item is-active" data-filter="blog">Blog</button>
     <button class="filter-item" data-filter="thoughts">Thoughts</button>
+    <button class="filter-item" data-filter="all">All</button>
   </nav>
 
   <div class="blog-list">
   <div class="blog-entry" data-type="blog">
-    <a href="/posts/c-guard/" class="blog-title">C-Guard: A Constitution-Grid Instrument for Data-Efficient RL Alignment</a>
+    <a href="/posts/c-guard/" class="blog-title">A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)</a>
     <span class="blog-date">Jul 2026</span>
   </div>
 
@@ -60,7 +48,7 @@ permalink: /posts/
     <span class="blog-date">Jul 2026</span>
   </div>
 
-  <div class="blog-entry" data-type="thoughts">
+  <div class="blog-entry" data-type="blog">
     <a href="https://x.com/lily_gpupoor/status/2070401977251659794" class="blog-title" target="_blank">Build a Dense Reward for Your Writing</a>
     <span class="blog-date">Jun 2026</span>
   </div>
@@ -70,12 +58,12 @@ permalink: /posts/
     <span class="blog-date">Jun 2026</span>
   </div>
 
-  <div class="blog-entry" data-type="thoughts">
+  <div class="blog-entry" data-type="blog">
     <a href="/posts/interaction-model/" class="blog-title">Thoughts on Thinking Machine's Interaction Model</a>
     <span class="blog-date">May 2026</span>
   </div>
 
-  <div class="blog-entry" data-type="blog">
+  <div class="blog-entry" data-type="thoughts">
     <a href="https://github.com/zarazhangrui/frontend-slides" class="blog-title" target="_blank">Frontend Slides: AI-Native Presentation Generation</a>
     <span class="blog-date">Apr 2026</span>
   </div>
@@ -100,15 +88,18 @@ permalink: /posts/
     <span class="blog-date">May 2025</span>
   </div>
 
-  <div class="blog-entry" data-type="blog">
-    <a href="/posts/test-time-scaling" class="blog-title">Test Time Scaling</a>
-    <span class="blog-date blog-soon">Coming soon</span>
   </div>
+</div>
 
-  <div class="blog-entry" data-type="blog">
-    <a href="/posts/contrastive-vs-generative-alignment" class="blog-title">Contrastive Alignment vs Generative Alignment</a>
-    <span class="blog-date blog-soon">Coming soon</span>
-  </div>
+<div class="motto-section">
+  <div class="motto-container">
+    <div class="motto-quote">
+      Pain is inevitable but suffering is optional
+    </div>
+    <div class="motto-attribution">
+      — Haruki Murakami
+    </div>
+
   </div>
 </div>
 
@@ -116,16 +107,19 @@ permalink: /posts/
 document.addEventListener('DOMContentLoaded', function () {
   var buttons = document.querySelectorAll('.posts-filter .filter-item');
   var entries = document.querySelectorAll('.blog-entry');
+  function apply(f) {
+    entries.forEach(function (e) {
+      e.style.display = (f === 'all' || e.getAttribute('data-type') === f) ? '' : 'none';
+    });
+  }
   buttons.forEach(function (btn) {
     btn.addEventListener('click', function () {
       buttons.forEach(function (b) { b.classList.remove('is-active'); });
       btn.classList.add('is-active');
-      var f = btn.getAttribute('data-filter');
-      entries.forEach(function (e) {
-        e.style.display = (f === 'all' || e.getAttribute('data-type') === f) ? '' : 'none';
-      });
+      apply(btn.getAttribute('data-filter'));
     });
   });
+  apply('blog');   // Blog is the default view
 });
 </script>
 
@@ -135,9 +129,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
 /* Motto Section */
 .motto-section {
-  max-width: 700px;
-  margin: 2rem auto 1.5rem;
-  padding: 0 1rem;
+  max-width: 828px;                  /* matches the posts column (860 minus its padding) */
+  margin: 3rem auto 2.5rem;          /* sits at the foot of the page now */
+  padding: 2rem 1rem 0;
+  border-top: 1px solid #e5e7eb;     /* hairline divider before the closing note */
   text-align: center;
 }
 
@@ -148,7 +143,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 .motto-quote {
   display: inline;   /* quote + attribution on one line */
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-weight: 300;
   color: #1a202c;
   font-style: italic;
@@ -163,7 +158,7 @@ document.addEventListener('DOMContentLoaded', function () {
   margin-left: 0.6rem;   /* small gap after the quote */
   font-style: italic;    /* fully uniform with the quote — no hierarchy */
   font-family: Georgia, serif;
-  font-size: 1.25rem;    /* same size as the quote */
+  font-size: 1rem;       /* same size as the quote */
   color: #1a202c;        /* same color as the quote */
   margin-bottom: 0;
   font-weight: 300;
@@ -174,7 +169,7 @@ document.addEventListener('DOMContentLoaded', function () {
 @media (max-width: 768px) {
   .motto-quote,
   .motto-attribution {
-    font-size: 1.125rem;   /* keep quote + name the same size on mobile too */
+    font-size: 0.95rem;   /* keep quote + name the same size on mobile too */
   }
 
   /* on phones, drop the "— Haruki Murakami" to its own second line */
@@ -227,6 +222,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
 .filter-item:hover {
   color: #1e3a8a;
+}
+
+/* kill the browser's default focus ring/box on click; keep it for keyboard nav */
+.filter-item:focus {
+  outline: none;
+}
+
+.filter-item:focus-visible {
+  outline: 2px solid #2437e7;
+  outline-offset: 2px;
 }
 
 .filter-item.is-active {
@@ -344,9 +349,15 @@ document.addEventListener('DOMContentLoaded', function () {
 }
 
 /* Hover: no underline (the entry divider already draws a line) —
-   just light the title up in the accent blue, Cognition-style */
-.blog-title:hover {
+   light the whole row up in the accent blue, Cognition-style.
+   Row-level hover so title and date change together. */
+.blog-entry:hover .blog-title,
+.blog-entry:hover .blog-date {
   color: #2437e7 !important;
+}
+
+.blog-date {
+  transition: color 0.2s ease;
 }
 
 /* Remove underline from all link states */

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -27,82 +27,107 @@ permalink: /posts/
   </div>
 </div>
 
-<div class="blog-list">
-  <div class="blog-entry">
+<div class="posts-layout">
+  <nav class="posts-filter" aria-label="Post type filter">
+    <button class="filter-item is-active" data-filter="all">All</button>
+    <button class="filter-item" data-filter="blog">Blog</button>
+    <button class="filter-item" data-filter="thoughts">Thoughts</button>
+  </nav>
+
+  <div class="blog-list">
+  <div class="blog-entry" data-type="blog">
     <a href="/posts/c-guard/" class="blog-title">C-Guard: A Constitution-Grid Instrument for Data-Efficient RL Alignment</a>
     <span class="blog-date">Jul 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2076794330401087964" class="blog-title" target="_blank">My Take on the $100B Market for AI Training Data, Including RL Environments</a>
     <span class="blog-date">Jul 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2076114858203095503" class="blog-title" target="_blank">Second-Order Effects After Cursor and Cognition Cracked Post-Training</a>
     <span class="blog-date">Jul 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2074728312161849627" class="blog-title" target="_blank">Reflection: Where Is the Market for Post-Training as a Service?</a>
     <span class="blog-date">Jul 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2072083403898507278" class="blog-title" target="_blank">Poster @ AI Engineer World's Fair: Is Speculative Decoding All We Need?</a>
     <span class="blog-date">Jul 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2070401977251659794" class="blog-title" target="_blank">Build a Dense Reward for Your Writing</a>
     <span class="blog-date">Jun 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="/posts/harbor-rlvr-environment/" class="blog-title">What Can't Be Measured Can't Be Solved: RLVR Environment Design from a Failure Taxonomy</a>
     <span class="blog-date">Jun 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="thoughts">
     <a href="/posts/interaction-model/" class="blog-title">Thoughts on Thinking Machine's Interaction Model</a>
     <span class="blog-date">May 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="https://github.com/zarazhangrui/frontend-slides" class="blog-title" target="_blank">Frontend Slides: AI-Native Presentation Generation</a>
     <span class="blog-date">Apr 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="https://skill-claw.vercel.app/" class="blog-title" target="_blank">Skill Claw: Self-Improving Robot Agents</a>
     <span class="blog-date">Mar 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="https://supergeneral.vercel.app/" class="blog-title" target="_blank">SuperGeneral: Compositional Tool Environments for Agent Training</a>
     <span class="blog-date">Mar 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="https://sofagenius.ai/" class="blog-title" target="_blank">SofaGenius: Multi-Agent ML Research Assistant</a>
     <span class="blog-date">Feb 2026</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="/posts/ieee-most-panel" class="blog-title">IEEE MOST Panel: Driving Force Towards Large-Scale AV Commercialization</a>
     <span class="blog-date">May 2025</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="/posts/test-time-scaling" class="blog-title">Test Time Scaling</a>
     <span class="blog-date blog-soon">Coming soon</span>
   </div>
 
-  <div class="blog-entry">
+  <div class="blog-entry" data-type="blog">
     <a href="/posts/contrastive-vs-generative-alignment" class="blog-title">Contrastive Alignment vs Generative Alignment</a>
     <span class="blog-date blog-soon">Coming soon</span>
   </div>
+  </div>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  var buttons = document.querySelectorAll('.posts-filter .filter-item');
+  var entries = document.querySelectorAll('.blog-entry');
+  buttons.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      buttons.forEach(function (b) { b.classList.remove('is-active'); });
+      btn.classList.add('is-active');
+      var f = btn.getAttribute('data-filter');
+      entries.forEach(function (e) {
+        e.style.display = (f === 'all' || e.getAttribute('data-type') === f) ? '' : 'none';
+      });
+    });
+  });
+});
+</script>
 
 <style>
 /* Header + nav come from the shared site CSS (main.css) via the splash layout,
@@ -164,12 +189,114 @@ permalink: /posts/
   }
 }
 
+/* ---- Posts layout: vertical filter sidebar + hairline divider (Cognition-style) ---- */
+.posts-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  max-width: 860px;
+  margin: 1.5rem auto 3rem;
+  padding: 0 1rem;
+}
+
+.posts-filter {
+  flex: 0 0 120px;
+  position: sticky;
+  top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding-top: 0.9rem;   /* level with the first entry's title */
+}
+
+.filter-item {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0 0 0 0.75rem;
+  margin: 0;
+  text-align: left;
+  font-size: 0.95rem;
+  font-weight: 400;
+  color: #1a202c;
+  cursor: pointer;
+  line-height: 1.5;
+  border-left: 2px solid transparent;   /* reserve space for the indicator */
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.filter-item:hover {
+  color: #1e3a8a;
+}
+
+.filter-item.is-active {
+  color: #2437e7;                 /* Cognition-style blue */
+  border-left: 2px solid #2437e7; /* the "|" indicator */
+}
+
 .blog-list {
   /* wider than the title's ~600px so the reserved date column doesn't force
      titles to wrap early — line 1 stays long like the original */
+  flex: 1 1 auto;
+  min-width: 0;
   max-width: 700px;
-  margin: 1.5rem auto 3rem;
-  padding: 0 1rem;
+  margin: 0;
+  padding: 0 0 0 2rem;
+  border-left: 1px solid #e5e7eb;   /* hairline column divider */
+  position: relative;
+}
+
+/* Cognition-style column furniture: a bolder tick at the top of the hairline… */
+.blog-list::before {
+  content: '';
+  position: absolute;
+  top: -0.5rem;
+  left: -1.5px;
+  width: 2px;
+  height: 14px;
+  background: #b3b8c2;
+}
+
+/* …and a small mono section number beside it */
+.blog-list::after {
+  content: '01';
+  position: absolute;
+  top: 0.15rem;
+  left: -2.6rem;
+  font-family: 'SFMono-Regular', Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  color: #b3b8c2;
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 768px) {
+  .posts-layout {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .posts-filter {
+    position: static;
+    flex-direction: row;
+    gap: 1.25rem;
+    padding-top: 0;
+  }
+
+  .filter-item {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    padding: 0 0 0.25rem 0;
+  }
+
+  .filter-item.is-active {
+    border-left: none;
+    border-bottom: 2px solid #2437e7;
+  }
+
+  .blog-list {
+    border-left: none;
+    padding-left: 0;
+  }
 }
 
 .blog-entry {

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -386,7 +386,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   flex: 0 0 4.6rem;       /* fixed column so every title starts on the same rail */
   white-space: nowrap;
   font-family: 'SFMono-Regular', Menlo, Consolas, monospace !important;   /* same face as the 01 marker; beats override.css's span rule */
-  font-size: 0.68rem;
+  font-size: 10px;
   color: #9aa4b2;
   letter-spacing: 0.02em;
 }

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -63,11 +63,6 @@ permalink: /posts/
     <span class="blog-date">05.20.26</span>
   </div>
 
-  <div class="blog-entry" data-type="thoughts">
-    <a href="https://github.com/zarazhangrui/frontend-slides" class="blog-title" target="_blank">Frontend Slides: AI-Native Presentation Generation</a>
-    <span class="blog-date">Apr 2026</span>
-  </div>
-
   <div class="blog-entry" data-type="blog">
     <a href="https://skill-claw.vercel.app/" class="blog-title" target="_blank">Skill Claw: Self-Improving Robot Agents</a>
     <span class="blog-date">03.15.26</span>
@@ -78,6 +73,11 @@ permalink: /posts/
     <span class="blog-date">03.10.26</span>
   </div>
 
+  <div class="blog-entry" data-type="thoughts">
+    <a href="https://github.com/zarazhangrui/frontend-slides" class="blog-title" target="_blank">Frontend Slides: AI-Native Presentation Generation</a>
+    <span class="blog-date">02.27.26</span>
+  </div>
+
   <div class="blog-entry" data-type="blog">
     <a href="https://sofagenius.ai/" class="blog-title" target="_blank">SofaGenius: Multi-Agent ML Research Assistant</a>
     <span class="blog-date">02.21.26</span>
@@ -85,7 +85,7 @@ permalink: /posts/
 
   <div class="blog-entry" data-type="thoughts">
     <a href="/posts/ieee-most-panel" class="blog-title">IEEE MOST Panel: Driving Force Towards Large-Scale AV Commercialization</a>
-    <span class="blog-date">May 2025</span>
+    <span class="blog-date">05.05.25</span>
   </div>
 
   </div>

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -385,7 +385,8 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   order: -1;              /* date leads the row, Cognition-style */
   flex: 0 0 4.6rem;       /* fixed column so every title starts on the same rail */
   white-space: nowrap;
-  font-size: 0.85rem;   /* same serif as the rest of the page */
+  font-family: 'SFMono-Regular', Menlo, Consolas, monospace;   /* same face as the 01 marker */
+  font-size: 0.78rem;
   color: #9aa4b2;
   letter-spacing: 0.02em;
 }

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', function () {
      header's line so the two frame the content */
   max-width: none;
   margin: 6rem 0 0;
-  padding: 2.5rem 1rem 3rem;
+  padding: 1rem 1rem 1.25rem;   /* tight under the rule — reads as a footnote */
   border-top: 1px solid #e7e9ee;
   text-align: center;
 }
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 .motto-quote {
   display: inline;   /* quote + attribution on one line */
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   font-weight: 300;
   color: #6b7280;   /* muted — footer furniture, not content */
   font-style: italic;
@@ -160,7 +160,7 @@ document.addEventListener('DOMContentLoaded', function () {
   margin-left: 0.6rem;   /* small gap after the quote */
   font-style: italic;    /* fully uniform with the quote — no hierarchy */
   font-family: Georgia, serif;
-  font-size: 0.9rem;     /* same size as the quote */
+  font-size: 0.8rem;     /* same size as the quote */
   color: #6b7280;        /* same color as the quote */
   margin-bottom: 0;
   font-weight: 300;
@@ -197,13 +197,16 @@ document.addEventListener('DOMContentLoaded', function () {
 }
 
 .posts-filter {
-  flex: 0 0 120px;
+  flex: 0 0 110px;
+  margin-right: 3rem;    /* clear air between the menu column and the content rail */
   position: sticky;
   top: 2rem;
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
   padding-top: 0.9rem;   /* level with the first entry's title */
+  padding-left: 0.9rem;
+  border-left: 1px solid #e7e9ee;   /* the menu column's own rail */
 }
 
 .filter-item {
@@ -264,14 +267,14 @@ document.addEventListener('DOMContentLoaded', function () {
   background: #b3b8c2;
 }
 
-/* …and a small mono section number beside it */
+/* …and a tiny mono section number hugging the rule, Cognition-style */
 .blog-list::after {
   content: '01';
   position: absolute;
-  top: 0.15rem;
-  left: -2.6rem;
+  top: -0.1rem;
+  left: 0.35rem;
   font-family: 'SFMono-Regular', Menlo, Consolas, monospace;
-  font-size: 0.72rem;
+  font-size: 0.62rem;
   color: #b3b8c2;
   letter-spacing: 0.04em;
 }
@@ -287,6 +290,15 @@ document.addEventListener('DOMContentLoaded', function () {
     flex-direction: row;
     gap: 1.25rem;
     padding-top: 0;
+    padding-left: 0;
+    border-left: none;
+    margin-right: 0;
+  }
+
+  /* column furniture is a desktop-only device */
+  .blog-list::before,
+  .blog-list::after {
+    display: none;
   }
 
   .filter-item {
@@ -324,8 +336,8 @@ document.addEventListener('DOMContentLoaded', function () {
 }
 
 .blog-date {
-  flex: 0 0 auto;
-  margin-left: auto;   /* push the date to the far-right corner */
+  order: -1;              /* date leads the row, Cognition-style */
+  flex: 0 0 4.6rem;       /* fixed column so every title starts on the same rail */
   white-space: nowrap;
   font-family: 'SFMono-Regular', Menlo, Consolas, monospace;   /* matches the 01 section number */
   font-size: 0.78rem;

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -214,7 +214,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   gap: 0;
   max-width: 860px;
   width: 100%;
-  margin: 1.5rem auto 7rem;   /* generous clearance above the footer rule */
+  margin: 1.5rem auto 14rem;   /* footer sits far below the content, at the very end of the scroll */
   padding: 0 1rem;
   position: relative;
 }
@@ -249,7 +249,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
-  padding-top: 0.9rem;   /* level with the first entry's title */
+  padding-top: 0;         /* menu starts level with the 01 marker */
   padding-left: 0.15rem;  /* text hugs the rail, evenly for every item */
 }
 
@@ -313,10 +313,10 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
 .blog-list::after {
   content: '01';
   position: absolute;
-  top: -0.1rem;
+  top: 0;
   left: 0.35rem;
   font-family: 'SFMono-Regular', Menlo, Consolas, monospace;
-  font-size: 0.62rem;
+  font-size: 0.5rem;   /* very small, Cognition-style */
   color: #b3b8c2;
   letter-spacing: 0.04em;
 }

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -154,7 +154,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   max-width: none;
   margin: 6rem 0 0;
   margin-top: auto;             /* absorb leftover viewport height — line sits at the very bottom */
-  padding: 1rem 1rem 1.25rem;   /* tight under the rule — reads as a footnote */
+  padding: 0.5rem 1rem 0.6rem;   /* a flat band — line, breath, text, done */
   border-top: 1px solid #e7e9ee;
   text-align: center;
 }

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -25,42 +25,42 @@ permalink: /posts/
   <div class="blog-list">
   <div class="blog-entry" data-type="blog">
     <a href="/posts/c-guard/" class="blog-title">A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)</a>
-    <span class="blog-date">Jul 2026</span>
+    <span class="blog-date">07.21.26</span>
   </div>
 
   <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2076794330401087964" class="blog-title" target="_blank">My Take on the $100B Market for AI Training Data, Including RL Environments</a>
-    <span class="blog-date">Jul 2026</span>
+    <span class="blog-date">07.13.26</span>
   </div>
 
   <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2076114858203095503" class="blog-title" target="_blank">Second-Order Effects After Cursor and Cognition Cracked Post-Training</a>
-    <span class="blog-date">Jul 2026</span>
+    <span class="blog-date">07.12.26</span>
   </div>
 
   <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2074728312161849627" class="blog-title" target="_blank">Reflection: Where Is the Market for Post-Training as a Service?</a>
-    <span class="blog-date">Jul 2026</span>
+    <span class="blog-date">07.08.26</span>
   </div>
 
   <div class="blog-entry" data-type="thoughts">
     <a href="https://x.com/lily_gpupoor/status/2072083403898507278" class="blog-title" target="_blank">Poster @ AI Engineer World's Fair: Is Speculative Decoding All We Need?</a>
-    <span class="blog-date">Jul 2026</span>
+    <span class="blog-date">06.30.26</span>
   </div>
 
   <div class="blog-entry" data-type="blog">
     <a href="https://x.com/lily_gpupoor/status/2070401977251659794" class="blog-title" target="_blank">Build a Dense Reward for Your Writing</a>
-    <span class="blog-date">Jun 2026</span>
+    <span class="blog-date">06.26.26</span>
   </div>
 
   <div class="blog-entry" data-type="blog">
     <a href="/posts/harbor-rlvr-environment/" class="blog-title">What Can't Be Measured Can't Be Solved: RLVR Environment Design from a Failure Taxonomy</a>
-    <span class="blog-date">Jun 2026</span>
+    <span class="blog-date">06.10.26</span>
   </div>
 
   <div class="blog-entry" data-type="blog">
     <a href="/posts/interaction-model/" class="blog-title">Thoughts on Thinking Machine's Interaction Model</a>
-    <span class="blog-date">May 2026</span>
+    <span class="blog-date">05.20.26</span>
   </div>
 
   <div class="blog-entry" data-type="thoughts">
@@ -325,9 +325,10 @@ document.addEventListener('DOMContentLoaded', function () {
   flex: 0 0 auto;
   margin-left: auto;   /* push the date to the far-right corner */
   white-space: nowrap;
-  font-size: 0.85rem;
+  font-family: 'SFMono-Regular', Menlo, Consolas, monospace;   /* matches the 01 section number */
+  font-size: 0.78rem;
   color: #9aa4b2;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
 }
 
 .blog-date.blog-soon {

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -385,8 +385,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   order: -1;              /* date leads the row, Cognition-style */
   flex: 0 0 4.6rem;       /* fixed column so every title starts on the same rail */
   white-space: nowrap;
-  font-family: 'SFMono-Regular', Menlo, Consolas, monospace;   /* matches the 01 section number */
-  font-size: 0.78rem;
+  font-size: 0.85rem;   /* same serif as the rest of the page */
   color: #9aa4b2;
   letter-spacing: 0.02em;
 }

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -386,7 +386,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   flex: 0 0 4.6rem;       /* fixed column so every title starts on the same rail */
   white-space: nowrap;
   font-family: 'SFMono-Regular', Menlo, Consolas, monospace !important;   /* same face as the 01 marker; beats override.css's span rule */
-  font-size: 0.78rem;
+  font-size: 0.68rem;
   color: #9aa4b2;
   letter-spacing: 0.02em;
 }

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -214,30 +214,31 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   gap: 0;
   max-width: 860px;
   width: 100%;
-  margin: 1.5rem auto 4rem;   /* guaranteed clearance above the footer rule */
+  margin: 1.5rem auto 7rem;   /* generous clearance above the footer rule */
   padding: 0 1rem;
   position: relative;
 }
 
-/* menu column rail: tick at the top, line running the full height of the section */
-.posts-layout::before {
-  content: '';
-  position: absolute;
-  top: -0.5rem;
-  left: calc(1rem - 1px);
-  width: 2px;
-  height: 14px;
-  background: #b3b8c2;
-}
-
+/* Column rails: each starts with a bold tick flush against the header line
+   (70px above this box) and runs a 1px hairline to the bottom of the section. */
+.posts-layout::before,
 .posts-layout::after {
   content: '';
   position: absolute;
-  top: -0.5rem;
+  top: -70px;      /* reach up to the header's horizontal rule */
   bottom: 0;
-  left: 1rem;
-  width: 1px;
-  background: #e7e9ee;
+  width: 2px;
+  background:
+    linear-gradient(#b3b8c2, #b3b8c2) 0 0 / 2px 14px no-repeat,
+    linear-gradient(#e7e9ee, #e7e9ee) 0.5px 14px / 1px calc(100% - 14px) no-repeat;
+}
+
+.posts-layout::before {
+  left: calc(1rem - 1px);              /* menu column rail */
+}
+
+.posts-layout::after {
+  left: calc(4rem + 110px - 1px);      /* content column rail (menu 110px + 3rem air) */
 }
 
 .posts-filter {
@@ -305,22 +306,10 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   max-width: 700px;
   margin: 0;
   padding: 0 0 0 2rem;
-  border-left: 1px solid #e5e7eb;   /* hairline column divider */
-  position: relative;
+  position: relative;   /* rail itself is drawn by .posts-layout::after */
 }
 
-/* Cognition-style column furniture: a bolder tick at the top of the hairline… */
-.blog-list::before {
-  content: '';
-  position: absolute;
-  top: -0.5rem;
-  left: -1.5px;
-  width: 2px;
-  height: 14px;
-  background: #b3b8c2;
-}
-
-/* …and a tiny mono section number hugging the rule, Cognition-style */
+/* a tiny mono section number hugging the rule, Cognition-style */
 .blog-list::after {
   content: '01';
   position: absolute;

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -227,7 +227,7 @@ document.addEventListener('DOMContentLoaded', function () {
   flex-direction: column;
   gap: 0.55rem;
   padding-top: 0.9rem;   /* level with the first entry's title */
-  padding-left: 0.9rem;  /* text aligns to the rail, evenly for every item */
+  padding-left: 0.35rem;  /* text hugs the rail, evenly for every item */
 }
 
 .filter-item {
@@ -268,7 +268,7 @@ document.addEventListener('DOMContentLoaded', function () {
 .filter-item.is-active::before {
   content: '';
   position: absolute;
-  left: -1.5rem;
+  left: -1rem;
   top: 0.15em;
   width: 3px;
   height: 1.1em;

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -430,5 +430,9 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   border-bottom: none !important;
   outline: none !important;
 }
+
+    /* Brand-blue text selection */
+    ::selection { background: #2437e7; color: #fff; }
+    ::-moz-selection { background: #2437e7; color: #fff; }
 </style>
 

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -129,10 +129,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
 /* Motto Section */
 .motto-section {
-  max-width: 828px;                  /* matches the posts column (860 minus its padding) */
-  margin: 3rem auto 2.5rem;          /* sits at the foot of the page now */
-  padding: 2rem 1rem 0;
-  border-top: 1px solid #e5e7eb;     /* hairline divider before the closing note */
+  /* a true full-width footer: the top rule spans the page, echoing the
+     header's line so the two frame the content */
+  max-width: none;
+  margin: 6rem 0 0;
+  padding: 2.5rem 1rem 3rem;
+  border-top: 1px solid #e7e9ee;
   text-align: center;
 }
 
@@ -143,9 +145,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
 .motto-quote {
   display: inline;   /* quote + attribution on one line */
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 300;
-  color: #1a202c;
+  color: #6b7280;   /* muted — footer furniture, not content */
   font-style: italic;
   line-height: 1.5;
   margin-bottom: 0;
@@ -158,8 +160,8 @@ document.addEventListener('DOMContentLoaded', function () {
   margin-left: 0.6rem;   /* small gap after the quote */
   font-style: italic;    /* fully uniform with the quote — no hierarchy */
   font-family: Georgia, serif;
-  font-size: 1rem;       /* same size as the quote */
-  color: #1a202c;        /* same color as the quote */
+  font-size: 0.9rem;     /* same size as the quote */
+  color: #6b7280;        /* same color as the quote */
   margin-bottom: 0;
   font-weight: 300;
 }

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -127,12 +127,33 @@ document.addEventListener('DOMContentLoaded', function () {
 /* Header + nav come from the shared site CSS (main.css) via the splash layout,
    so this page matches Home and Papers exactly (background, zoom, header). */
 
+/* Pin the footer to the viewport bottom when the (filtered) list is short:
+   stretch the page's wrapper chain and let the motto take the slack. */
+body.sticky-bottom-footer {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+body.sticky-bottom-footer > .container.mt-5 {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+}
+
+body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+}
+
 /* Motto Section */
 .motto-section {
   /* a true full-width footer: the top rule spans the page, echoing the
      header's line so the two frame the content */
   max-width: none;
   margin: 6rem 0 0;
+  margin-top: auto;             /* absorb leftover viewport height — line sits at the very bottom */
   padding: 1rem 1rem 1.25rem;   /* tight under the rule — reads as a footnote */
   border-top: 1px solid #e7e9ee;
   text-align: center;
@@ -192,7 +213,8 @@ document.addEventListener('DOMContentLoaded', function () {
   align-items: flex-start;
   gap: 0;
   max-width: 860px;
-  margin: 1.5rem auto 3rem;
+  width: 100%;
+  margin: 1.5rem auto 4rem;   /* guaranteed clearance above the footer rule */
   padding: 0 1rem;
   position: relative;
 }
@@ -227,7 +249,7 @@ document.addEventListener('DOMContentLoaded', function () {
   flex-direction: column;
   gap: 0.55rem;
   padding-top: 0.9rem;   /* level with the first entry's title */
-  padding-left: 0.35rem;  /* text hugs the rail, evenly for every item */
+  padding-left: 0.15rem;  /* text hugs the rail, evenly for every item */
 }
 
 .filter-item {

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -343,26 +343,10 @@ document.addEventListener('DOMContentLoaded', function () {
   transition: color 0.2s ease;
 }
 
-.blog-title::after {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 1px;
-  bottom: -2px;
-  left: 0;
-  background-color: #1e3a8a;
-  visibility: hidden;
-  transform: scaleX(0);
-  transition: all 0.3s ease-in-out;
-}
-
+/* Hover: no underline (the entry divider already draws a line) —
+   just light the title up in the accent blue, Cognition-style */
 .blog-title:hover {
-  color: #1e3a8a !important;
-}
-
-.blog-title:hover::after {
-  visibility: visible;
-  transform: scaleX(1);
+  color: #2437e7 !important;
 }
 
 /* Remove underline from all link states */

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -292,9 +292,9 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   content: '';
   position: absolute;
   left: -1rem;
-  top: 0.15em;
+  top: 0.32em;
   width: 3px;
-  height: 1.1em;
+  height: 0.78em;   /* matches the text's cap height, no taller */
   background: #2437e7;
 }
 

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -385,7 +385,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
   order: -1;              /* date leads the row, Cognition-style */
   flex: 0 0 4.6rem;       /* fixed column so every title starts on the same rail */
   white-space: nowrap;
-  font-family: 'SFMono-Regular', Menlo, Consolas, monospace;   /* same face as the 01 marker */
+  font-family: 'SFMono-Regular', Menlo, Consolas, monospace !important;   /* same face as the 01 marker; beats override.css's span rule */
   font-size: 0.78rem;
   color: #9aa4b2;
   letter-spacing: 0.02em;

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -44,7 +44,7 @@ permalink: /posts/
   </div>
 
   <div class="blog-entry" data-type="thoughts">
-    <a href="https://x.com/lily_gpupoor/status/2072083403898507278" class="blog-title" target="_blank">Poster @ AI Engineer World's Fair: Is Speculative Decoding All We Need?</a>
+    <a href="https://x.com/lily_gpupoor/status/2072083403898507278" class="blog-title" target="_blank">AI Engineer World's Fair: Is Speculative Decoding All We Need?</a>
     <span class="blog-date">06.30.26</span>
   </div>
 
@@ -70,7 +70,7 @@ permalink: /posts/
 
   <div class="blog-entry" data-type="blog">
     <a href="https://skill-claw.vercel.app/" class="blog-title" target="_blank">Skill Claw: Self-Improving Robot Agents</a>
-    <span class="blog-date">Mar 2026</span>
+    <span class="blog-date">03.15.26</span>
   </div>
 
   <div class="blog-entry" data-type="blog">
@@ -80,7 +80,7 @@ permalink: /posts/
 
   <div class="blog-entry" data-type="blog">
     <a href="https://sofagenius.ai/" class="blog-title" target="_blank">SofaGenius: Multi-Agent ML Research Assistant</a>
-    <span class="blog-date">Feb 2026</span>
+    <span class="blog-date">02.21.26</span>
   </div>
 
   <div class="blog-entry" data-type="thoughts">

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -291,7 +291,7 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
 .filter-item.is-active::before {
   content: '';
   position: absolute;
-  left: -1rem;
+  left: -0.5rem;   /* just off the rail */
   top: 0.32em;
   width: 3px;
   height: 0.78em;   /* matches the text's cap height, no taller */

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -182,7 +182,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
   
   .motto-section {
-    margin: 2.5rem auto 3.5rem;
+    margin: 4rem 0 0;   /* full-width footer on mobile too, flush to the page end */
   }
 }
 
@@ -194,6 +194,28 @@ document.addEventListener('DOMContentLoaded', function () {
   max-width: 860px;
   margin: 1.5rem auto 3rem;
   padding: 0 1rem;
+  position: relative;
+}
+
+/* menu column rail: tick at the top, line running the full height of the section */
+.posts-layout::before {
+  content: '';
+  position: absolute;
+  top: -0.5rem;
+  left: calc(1rem - 1px);
+  width: 2px;
+  height: 14px;
+  background: #b3b8c2;
+}
+
+.posts-layout::after {
+  content: '';
+  position: absolute;
+  top: -0.5rem;
+  bottom: 0;
+  left: 1rem;
+  width: 1px;
+  background: #e7e9ee;
 }
 
 .posts-filter {
@@ -205,24 +227,23 @@ document.addEventListener('DOMContentLoaded', function () {
   flex-direction: column;
   gap: 0.55rem;
   padding-top: 0.9rem;   /* level with the first entry's title */
-  padding-left: 0.9rem;
-  border-left: 1px solid #e7e9ee;   /* the menu column's own rail */
+  padding-left: 0.9rem;  /* text aligns to the rail, evenly for every item */
 }
 
 .filter-item {
   appearance: none;
   background: none;
   border: none;
-  padding: 0 0 0 0.75rem;
+  padding: 0;
   margin: 0;
+  position: relative;
   text-align: left;
   font-size: 0.95rem;
   font-weight: 400;
   color: #1a202c;
   cursor: pointer;
   line-height: 1.5;
-  border-left: 2px solid transparent;   /* reserve space for the indicator */
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition: color 0.15s ease;
 }
 
 .filter-item:hover {
@@ -240,8 +261,18 @@ document.addEventListener('DOMContentLoaded', function () {
 }
 
 .filter-item.is-active {
-  color: #2437e7;                 /* Cognition-style blue */
-  border-left: 2px solid #2437e7; /* the "|" indicator */
+  color: #2437e7;   /* Cognition-style blue */
+}
+
+/* the "|" indicator floats just outside the rail, like Cognition's */
+.filter-item.is-active::before {
+  content: '';
+  position: absolute;
+  left: -1.5rem;
+  top: 0.15em;
+  width: 3px;
+  height: 1.1em;
+  background: #2437e7;
 }
 
 .blog-list {
@@ -288,6 +319,7 @@ document.addEventListener('DOMContentLoaded', function () {
   .posts-filter {
     position: static;
     flex-direction: row;
+    align-items: baseline;   /* don't stretch buttons — keep the underline snug */
     gap: 1.25rem;
     padding-top: 0;
     padding-left: 0;
@@ -297,7 +329,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
   /* column furniture is a desktop-only device */
   .blog-list::before,
-  .blog-list::after {
+  .blog-list::after,
+  .posts-layout::before,
+  .posts-layout::after,
+  .filter-item.is-active::before {
     display: none;
   }
 

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -5,7 +5,7 @@
   padding: 0;
   font-size: 1rem;           /* standard size for paper list */
   line-height: 1.6;
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
   color: var(--text-color);
 }
 
@@ -18,12 +18,12 @@
 .bibliography cite {
   font-style: italic;        /* ensure italics even if theme overrides <cite> */
   color: var(--text-color);
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
 }
 
 .bibliography strong {
   font-weight: 500;          /* slightly less bold for paper titles */
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
 }
 
 
@@ -55,7 +55,7 @@
 .page__content .intro-text p {
   font-size: 1rem;   /* reduced from 1.2rem */
   line-height: 1.5;
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
   color: var(--text-color);
   margin-bottom: 0.8rem; /* reduced from 1.5rem */
 }
@@ -83,7 +83,7 @@
 
 /* Update all headings to use EB Garamond like Jason Wei */
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
   color: var(--heading-color);
   font-weight: 400;
 }
@@ -198,11 +198,11 @@ body {
 
 .author-name {
   font-size: 2.5rem;
-  font-weight: 400;
+  font-weight: 300;
   margin: 0;
   padding: 0;
   color: var(--heading-color);
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
 }
 
 .navigation-container {
@@ -216,7 +216,7 @@ body {
   text-decoration: none;
   font-weight: 400;
   position: relative;
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
 }
 
 .nav-link:hover {
@@ -243,7 +243,7 @@ body {
 
 /* Cooking placeholder styling */
 .cooking-placeholder {
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
   font-size: 1.5rem;
   color: var(--text-color);
   text-align: center;
@@ -419,7 +419,7 @@ body {
   font-weight: 400;
   color: var(--text-color);
   font-style: normal;
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
   width: 100%;
   padding: 0 0.5rem;
   box-sizing: border-box;
@@ -433,7 +433,7 @@ body {
   color: rgba(0, 0, 0, 0.6);
   display: block;
   margin-top: 0.25rem;
-  font-family: 'EB Garamond', serif;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif;
   font-style: italic;
   text-align: center;
   width: 100%;

--- a/assets/css/override.css
+++ b/assets/css/override.css
@@ -8,7 +8,7 @@
 /* Base body styles */
 body {
   background-color: var(--background-color);
-  font-family: 'EB Garamond', serif !important;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif !important;
   color: var(--text-color);
   font-weight: 400;
   line-height: 1.6;
@@ -104,20 +104,20 @@ a.site-title,
 
 /* Typography settings */
 p, li, span, div, a, figcaption {
-  font-family: 'EB Garamond', serif !important;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif !important;
 }
 
 /* Navigation styling */
 .nav-link {
   font-size: 1.5rem !important;
-  font-family: 'EB Garamond', serif !important;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif !important;
   font-weight: 400 !important;
 }
 
 /* Intro text styling */
 .page__content .intro-text p,
 .intro-text p {
-  font-family: 'EB Garamond', serif !important;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif !important;
   font-size: 1.1rem !important;
   line-height: 1.5 !important;
   color: var(--text-color) !important;
@@ -125,13 +125,13 @@ p, li, span, div, a, figcaption {
 
 /* Heading styles */
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'EB Garamond', serif !important;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif !important;
   font-weight: 400 !important;
 }
 
 /* Form element styles */
 button, input, select, textarea {
-  font-family: 'EB Garamond', serif !important;
+  font-family: 'Cormorant Garamond', 'EB Garamond', serif !important;
 }
 
 /* Mobile responsive fixes */

--- a/posts/c-guard/index.html
+++ b/posts/c-guard/index.html
@@ -709,6 +709,7 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
       if (visible.length) setActive(visible[0].target.id);
     }, { rootMargin: '-12% 0px -70% 0px', threshold: 0 });
     targets.forEach(t => obs.observe(t));
+    if (targets.length) setActive(targets[0].id);   // first section active on load
   })();
 </script>
 

--- a/posts/c-guard/index.html
+++ b/posts/c-guard/index.html
@@ -97,7 +97,7 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
     }
 
     h1 {
-      font-family: var(--serif);
+      font-family: 'EB Garamond', Georgia, serif;   /* same face as the site name */
       font-size: clamp(2rem, 4.5vw, 2.55rem);
       font-weight: 400; letter-spacing: -0.012em; line-height: 1.12;
       color: var(--ink); margin-bottom: 1.5rem;

--- a/posts/c-guard/index.html
+++ b/posts/c-guard/index.html
@@ -191,7 +191,25 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
       .site-header-nav a { font-size: 30px; }
     }
     @media (max-width: 640px) { .site-name { font-size: 28px; } .site-header-nav a { font-size: 16px; } }
-  </style>
+  
+    /* Column rails carried over from the Posts index (Cognition-style) */
+    .layout { position: relative; }
+    .layout::before, .layout::after {
+      content: '';
+      position: absolute;
+      top: 4rem;
+      bottom: 6rem;
+      width: 2px;
+      background:
+        linear-gradient(#b3b8c2, #b3b8c2) 0 0 / 2px 14px no-repeat,
+        linear-gradient(#e7e9ee, #e7e9ee) 0.5px 14px / 1px calc(100% - 14px) no-repeat;
+    }
+    .layout::before { left: calc(2rem - 6px); }
+    .layout::after { left: calc(220px + 3.5rem); }
+    @media (max-width: 940px) {
+      .layout::before, .layout::after { display: none; }
+    }
+</style>
 </head>
 <body>
 

--- a/posts/c-guard/index.html
+++ b/posts/c-guard/index.html
@@ -76,15 +76,25 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
     .toc li { margin-bottom: 0.85rem; }
     .toc a {
       display: block;
+      position: relative;
       font: 500 0.875rem/1.35 var(--sans);
       color: rgba(0,0,0,0.42);
       padding-left: 0.85rem;
-      border-left: 2px solid transparent;
       text-decoration: none;
-      transition: color 0.15s, border-color 0.15s;
+      transition: color 0.15s;
     }
-    .toc a:hover { color: rgba(0,0,0,0.72); }
-    .toc a.active { color: #000; font-weight: 600; border-left-color: #000; }
+    .toc a:hover { color: #2437e7; }
+    .toc a.active { color: #2437e7; font-weight: 600; }
+    /* the "|" indicator floats left of the column rail, like the Posts filter */
+    .toc a.active::before {
+      content: '';
+      position: absolute;
+      left: -0.7rem;
+      top: 0.28em;
+      width: 3px;
+      height: 0.78em;
+      background: #2437e7;
+    }
 
     h1 {
       font-family: var(--serif);
@@ -197,7 +207,7 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
     .layout::before, .layout::after {
       content: '';
       position: absolute;
-      top: 4rem;
+      top: 0;   /* flush against the site header's rule */
       bottom: 6rem;
       width: 2px;
       background:

--- a/posts/c-guard/index.html
+++ b/posts/c-guard/index.html
@@ -3,19 +3,19 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>C-Guard: A Constitution-Grid Instrument for Data-Efficient RL Alignment</title>
-<meta property="og:title" content="C-Guard: A Constitution-Grid Instrument for Data-Efficient RL Alignment">
+<title>A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)</title>
+<meta property="og:title" content="A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)">
 <meta property="og:description" content="Training a safety guard with RL means optimizing two objectives that pull against each other. C-Guard turns data generation into measured moves on a constitution grid.">
 <meta property="og:image" content="https://lilyzhng.github.io/posts/c-guard/fig1-constitution-board.png">
 <meta property="og:url" content="https://lilyzhng.github.io/posts/c-guard/">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="C-Guard: A Constitution-Grid Instrument for Data-Efficient RL Alignment">
+<meta name="twitter:title" content="A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)">
 <meta name="twitter:description" content="Training a safety guard with RL means optimizing two objectives that pull against each other. C-Guard turns data generation into measured moves on a constitution grid.">
 <meta name="twitter:image" content="https://lilyzhng.github.io/posts/c-guard/fig1-constitution-board.png">
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;500&family=Inter:wght@400;500;600;700&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;500&family=Cormorant+Garamond:wght@300;400;500&family=Inter:wght@400;500;600;700&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet" />
 <script>
 MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
 </script>
@@ -97,7 +97,7 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
     }
 
     h1 {
-      font-family: 'EB Garamond', Georgia, serif;   /* same face as the site name */
+      font-family: 'Cormorant Garamond', 'EB Garamond', Georgia, serif;   /* same face as the site name */
       font-size: clamp(2rem, 4.5vw, 2.55rem);
       font-weight: 400; letter-spacing: -0.012em; line-height: 1.12;
       color: var(--ink); margin-bottom: 1.5rem;
@@ -184,7 +184,7 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
       display: flex; justify-content: space-between; align-items: center;
       padding: 32px 0; border-bottom: 1px solid #f2f2f2;
     }
-    .site-name { font-family: 'EB Garamond', Georgia, serif; font-size: 40px; font-weight: 400; line-height: 1.2; color: rgba(0,0,0,0.88); text-decoration: none; }
+    .site-name { font-family: 'Cormorant Garamond', 'EB Garamond', Georgia, serif; font-size: 40px; font-weight: 300; line-height: 1.2; color: rgba(0,0,0,0.88); text-decoration: none; }
     .site-header-nav { display: flex; gap: 24px; }
     .site-header-nav a { font-family: 'EB Garamond', Georgia, serif; font-size: 24px; color: rgba(0,0,0,0.88); text-decoration: none; }
     .site-header-nav a:hover { text-decoration: underline; }
@@ -258,7 +258,7 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
   </aside>
 
   <article>
-    <h1>C-Guard: A Constitution-Grid Instrument for Data-Efficient RL Alignment</h1>
+    <h1>A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)</h1>
     <div class="authors">
       <span class="avatar">LZ</span>
       <span class="who">Lily Zhang</span>
@@ -680,7 +680,7 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
       <h2>Citation</h2>
       <p>You can cite this post here:</p>
       <pre><code>@article{zhang2026cguard,
-  title   = "C-Guard: A Constitution-Grid Instrument for Data-Efficient RL Alignment",
+  title   = "A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)",
   author  = "Zhang, Lily",
   year    = "2026",
   month   = "July",

--- a/posts/c-guard/index.html
+++ b/posts/c-guard/index.html
@@ -219,6 +219,10 @@ MathJax = {tex: {inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']]}};
     @media (max-width: 940px) {
       .layout::before, .layout::after { display: none; }
     }
+
+    /* Brand-blue text selection */
+    ::selection { background: #2437e7; color: #fff; }
+    ::-moz-selection { background: #2437e7; color: #fff; }
 </style>
 </head>
 <body>

--- a/posts/harbor-rlvr-environment/index.html
+++ b/posts/harbor-rlvr-environment/index.html
@@ -12,7 +12,7 @@
   <meta name="twitter:card" content="summary" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;500&family=Inter:wght@400;500;600;700&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;500&family=Cormorant+Garamond:wght@300;400;500&family=Inter:wght@400;500;600;700&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet" />
   <style>
     :root {
       /* warm cream palette */
@@ -108,7 +108,7 @@
     .meta span + span::before { content: "·"; margin: 0 0.45rem; color: var(--faint); }
 
     h1 {
-      font-family: 'EB Garamond', Georgia, serif;   /* same face as the site name */
+      font-family: 'Cormorant Garamond', 'EB Garamond', Georgia, serif;   /* same face as the site name */
       font-size: clamp(2rem, 4.5vw, 2.55rem);
       font-weight: 400;
       letter-spacing: -0.012em;
@@ -334,7 +334,7 @@
       display: flex; justify-content: space-between; align-items: center;
       padding: 32px 0; border-bottom: 1px solid #f2f2f2;
     }
-    .site-name { font-family: 'EB Garamond', Georgia, serif; font-size: 40px; font-weight: 400; line-height: 1.2; color: rgba(0,0,0,0.88); text-decoration: none; }
+    .site-name { font-family: 'Cormorant Garamond', 'EB Garamond', Georgia, serif; font-size: 40px; font-weight: 300; line-height: 1.2; color: rgba(0,0,0,0.88); text-decoration: none; }
     .site-header-nav { display: flex; gap: 24px; }
     .site-header-nav a { font-family: 'EB Garamond', Georgia, serif; font-size: 24px; color: rgba(0,0,0,0.88); text-decoration: none; }
     .site-header-nav a:hover { text-decoration: underline; }

--- a/posts/harbor-rlvr-environment/index.html
+++ b/posts/harbor-rlvr-environment/index.html
@@ -76,15 +76,25 @@
     .toc li { margin-bottom: 0.85rem; }
     .toc a {
       display: block;
+      position: relative;
       font: 500 0.875rem/1.35 var(--sans);
       color: rgba(0,0,0,0.42);
       padding-left: 0.85rem;
-      border-left: 2px solid transparent;
       text-decoration: none;
-      transition: color 0.15s, border-color 0.15s;
+      transition: color 0.15s;
     }
-    .toc a:hover { color: rgba(0,0,0,0.72); }
-    .toc a.active { color: #000; font-weight: 600; border-left-color: #000; }
+    .toc a:hover { color: #2437e7; }
+    .toc a.active { color: #2437e7; font-weight: 600; }
+    /* the "|" indicator floats left of the column rail, like the Posts filter */
+    .toc a.active::before {
+      content: '';
+      position: absolute;
+      left: -0.7rem;
+      top: 0.28em;
+      width: 3px;
+      height: 0.78em;
+      background: #2437e7;
+    }
     .toc .sub a { font-size: 0.8125rem; padding-left: 1.65rem; }
     .toc .sub2 a { font-size: 0.75rem; padding-left: 2.45rem; }
     .toc .sub.active-parent a,
@@ -347,7 +357,7 @@
     .layout::before, .layout::after {
       content: '';
       position: absolute;
-      top: 4rem;
+      top: 0;   /* flush against the site header's rule */
       bottom: 6rem;
       width: 2px;
       background:

--- a/posts/harbor-rlvr-environment/index.html
+++ b/posts/harbor-rlvr-environment/index.html
@@ -1065,6 +1065,7 @@ std(R_{1..G}) > 0  for at least one task group</code></pre>
       if (visible.length) setActive(visible[0].target.id);
     }, { rootMargin: '-12% 0px -70% 0px', threshold: 0 });
     targets.forEach(t => obs.observe(t));
+    if (targets.length) setActive(targets[0].id);   // first section active on load
   })();
 </script>
 

--- a/posts/harbor-rlvr-environment/index.html
+++ b/posts/harbor-rlvr-environment/index.html
@@ -108,7 +108,7 @@
     .meta span + span::before { content: "·"; margin: 0 0.45rem; color: var(--faint); }
 
     h1 {
-      font-family: var(--serif);
+      font-family: 'EB Garamond', Georgia, serif;   /* same face as the site name */
       font-size: clamp(2rem, 4.5vw, 2.55rem);
       font-weight: 400;
       letter-spacing: -0.012em;

--- a/posts/harbor-rlvr-environment/index.html
+++ b/posts/harbor-rlvr-environment/index.html
@@ -369,6 +369,10 @@
     @media (max-width: 940px) {
       .layout::before, .layout::after { display: none; }
     }
+
+    /* Brand-blue text selection */
+    ::selection { background: #2437e7; color: #fff; }
+    ::-moz-selection { background: #2437e7; color: #fff; }
 </style>
 </head>
 <body>

--- a/posts/harbor-rlvr-environment/index.html
+++ b/posts/harbor-rlvr-environment/index.html
@@ -341,7 +341,25 @@
       .site-header-nav a { font-size: 30px; }
     }
     @media (max-width: 640px) { .site-name { font-size: 28px; } .site-header-nav a { font-size: 16px; } }
-  </style>
+  
+    /* Column rails carried over from the Posts index (Cognition-style) */
+    .layout { position: relative; }
+    .layout::before, .layout::after {
+      content: '';
+      position: absolute;
+      top: 4rem;
+      bottom: 6rem;
+      width: 2px;
+      background:
+        linear-gradient(#b3b8c2, #b3b8c2) 0 0 / 2px 14px no-repeat,
+        linear-gradient(#e7e9ee, #e7e9ee) 0.5px 14px / 1px calc(100% - 14px) no-repeat;
+    }
+    .layout::before { left: calc(2rem - 6px); }
+    .layout::after { left: calc(220px + 3.5rem); }
+    @media (max-width: 940px) {
+      .layout::before, .layout::after { display: none; }
+    }
+</style>
 </head>
 <body>
 

--- a/posts/interaction-model/index.html
+++ b/posts/interaction-model/index.html
@@ -380,7 +380,25 @@
       .site-header-nav a { font-size: 30px; }
     }
     @media (max-width: 640px) { .site-name { font-size: 28px; } .site-header-nav a { font-size: 16px; } }
-  </style>
+  
+    /* Column rails carried over from the Posts index (Cognition-style) */
+    .layout { position: relative; }
+    .layout::before, .layout::after {
+      content: '';
+      position: absolute;
+      top: 4rem;
+      bottom: 6rem;
+      width: 2px;
+      background:
+        linear-gradient(#b3b8c2, #b3b8c2) 0 0 / 2px 14px no-repeat,
+        linear-gradient(#e7e9ee, #e7e9ee) 0.5px 14px / 1px calc(100% - 14px) no-repeat;
+    }
+    .layout::before { left: calc(2rem - 6px); }
+    .layout::after { left: calc(220px + 3.5rem); }
+    @media (max-width: 940px) {
+      .layout::before, .layout::after { display: none; }
+    }
+</style>
 </head>
 <body>
 

--- a/posts/interaction-model/index.html
+++ b/posts/interaction-model/index.html
@@ -408,6 +408,10 @@
     @media (max-width: 940px) {
       .layout::before, .layout::after { display: none; }
     }
+
+    /* Brand-blue text selection */
+    ::selection { background: #2437e7; color: #fff; }
+    ::-moz-selection { background: #2437e7; color: #fff; }
 </style>
 </head>
 <body>

--- a/posts/interaction-model/index.html
+++ b/posts/interaction-model/index.html
@@ -81,15 +81,25 @@
     .toc li { margin-bottom: 0.85rem; }
     .toc a {
       display: block;
+      position: relative;
       font: 500 0.875rem/1.35 var(--sans);
       color: rgba(0,0,0,0.42);
       padding-left: 0.85rem;
-      border-left: 2px solid transparent;
       text-decoration: none;
-      transition: color 0.15s, border-color 0.15s;
+      transition: color 0.15s;
     }
-    .toc a:hover { color: rgba(0,0,0,0.72); }
-    .toc a.active { color: #000; font-weight: 600; border-left-color: #000; }
+    .toc a:hover { color: #2437e7; }
+    .toc a.active { color: #2437e7; font-weight: 600; }
+    /* the "|" indicator floats left of the column rail, like the Posts filter */
+    .toc a.active::before {
+      content: '';
+      position: absolute;
+      left: -0.7rem;
+      top: 0.28em;
+      width: 3px;
+      height: 0.78em;
+      background: #2437e7;
+    }
     .toc .sub a { font-size: 0.8125rem; padding-left: 1.65rem; }
     .toc .sub2 a { font-size: 0.75rem; padding-left: 2.45rem; }
     .toc .sub.active-parent a,
@@ -386,7 +396,7 @@
     .layout::before, .layout::after {
       content: '';
       position: absolute;
-      top: 4rem;
+      top: 0;   /* flush against the site header's rule */
       bottom: 6rem;
       width: 2px;
       background:

--- a/posts/interaction-model/index.html
+++ b/posts/interaction-model/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:image" content="https://lilyzhng.github.io/posts/interaction-model/og-image.png">
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;500&family=Inter:wght@400;500;600;700&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;500&family=Cormorant+Garamond:wght@300;400;500&family=Inter:wght@400;500;600;700&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet" />
 <style>
     :root {
       /* warm cream palette */
@@ -113,7 +113,7 @@
     .meta span + span::before { content: "·"; margin: 0 0.45rem; color: var(--faint); }
 
     h1 {
-      font-family: 'EB Garamond', Georgia, serif;   /* same face as the site name */
+      font-family: 'Cormorant Garamond', 'EB Garamond', Georgia, serif;   /* same face as the site name */
       font-size: clamp(2rem, 4.5vw, 2.55rem);
       font-weight: 400;
       letter-spacing: -0.012em;
@@ -373,7 +373,7 @@
       display: flex; justify-content: space-between; align-items: center;
       padding: 32px 0; border-bottom: 1px solid #f2f2f2;
     }
-    .site-name { font-family: 'EB Garamond', Georgia, serif; font-size: 40px; font-weight: 400; line-height: 1.2; color: rgba(0,0,0,0.88); text-decoration: none; }
+    .site-name { font-family: 'Cormorant Garamond', 'EB Garamond', Georgia, serif; font-size: 40px; font-weight: 300; line-height: 1.2; color: rgba(0,0,0,0.88); text-decoration: none; }
     .site-header-nav { display: flex; gap: 24px; }
     .site-header-nav a { font-family: 'EB Garamond', Georgia, serif; font-size: 24px; color: rgba(0,0,0,0.88); text-decoration: none; }
     .site-header-nav a:hover { text-decoration: underline; }

--- a/posts/interaction-model/index.html
+++ b/posts/interaction-model/index.html
@@ -647,6 +647,7 @@ function playYoutube(wrap, ytId) {
       if (visible.length) setActive(visible[0].target.id);
     }, { rootMargin: '-12% 0px -70% 0px', threshold: 0 });
     targets.forEach(t => obs.observe(t));
+    if (targets.length) setActive(targets[0].id);   // first section active on load
   })();
 </script>
 

--- a/posts/interaction-model/index.html
+++ b/posts/interaction-model/index.html
@@ -113,7 +113,7 @@
     .meta span + span::before { content: "·"; margin: 0 0.45rem; color: var(--faint); }
 
     h1 {
-      font-family: var(--serif);
+      font-family: 'EB Garamond', Georgia, serif;   /* same face as the site name */
       font-size: clamp(2rem, 4.5vw, 2.55rem);
       font-weight: 400;
       letter-spacing: -0.012em;


### PR DESCRIPTION
## Summary
- Posts index: vertical Blog / Thoughts / All filter (Blog default), Cognition-style column rails with top ticks + 01 marker, date-led rows in mono, exact MM.DD.YY dates, row-level blue hover, brand-blue text selection
- Footer: motto moved to a flat full-width band pinned to the end of the page
- Post pages (c-guard, harbor, interaction-model): same rails flush to the header rule, blue TOC indicator/hover with first-section default, EB Garamond -> Cormorant Garamond 300 site-wide masthead/titles
- C-Guard retitled to "A Constitution-Grid Instrument for Data-Efficient RL Alignment (C-Guard)"
- Fix: _config.yml excludes vendor so local jekyll serve builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)