### PR TITLE
Fix inconsistent top spacing of first post across filter tabs on mobile

### DIFF
--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -110,8 +110,18 @@ document.addEventListener('DOMContentLoaded', function () {
   var list = document.querySelector('.blog-list');
   var sectionNumbers = { blog: '01', thoughts: '02', all: '03' };
   function apply(f) {
+    var firstVisibleSet = false;
     entries.forEach(function (e) {
-      e.style.display = (f === 'all' || e.getAttribute('data-type') === f) ? '' : 'none';
+      var visible = (f === 'all' || e.getAttribute('data-type') === f);
+      e.style.display = visible ? '' : 'none';
+      // Tag the first *visible* entry so its top spacing can be trimmed to hug
+      // the tabs. :first-child can't do this because filtered-out entries are
+      // still in the DOM (display:none), so it targets a hidden element.
+      e.classList.remove('is-first-visible');
+      if (visible && !firstVisibleSet) {
+        e.classList.add('is-first-visible');
+        firstVisibleSet = true;
+      }
     });
     if (list) list.setAttribute('data-section', sectionNumbers[f] || '01');
   }
@@ -369,8 +379,10 @@ body.sticky-bottom-footer > .container.mt-5 > .container-fluid {
     padding-left: 0;
   }
 
-  /* first entry hugs the tabs, matching the papers page spacing */
-  .blog-entry:first-child {
+  /* first *visible* entry hugs the tabs, matching the papers page spacing.
+     Keyed off .is-first-visible (set in JS) rather than :first-child so the
+     spacing is consistent across every filter, not just the Blog tab. */
+  .blog-entry.is-first-visible {
     padding-top: 0;
   }
 }


### PR DESCRIPTION
The mobile 'first entry hugs the tabs' rule used :first-child, which targets
the first entry in the DOM. Since the filter hides non-matching entries with
display:none rather than removing them, :first-child pointed at a hidden entry
on the Thoughts/All tabs, leaving the first visible title with full top
padding and a larger gap than on the Blog tab.

Tag the first visible entry in JS (.is-first-visible) and trim its top padding
instead, so the first title hugs the tabs consistently across all filters.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ltex4SemF2WLmMobf6Mt8S